### PR TITLE
Add CI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+name: Release 
+jobs:
+  goreleaser:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.24"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi,

this change adds a GitHub Actions release workflow.
It will result in GitHub automatically releasing a full set of binaries for each architecture (like in this fork):
https://github.com/Manawyrm/unbound-exporter/releases/tag/v1.0.0

If you decide to merge this commit, please tag a new release to start an initial release.

Thanks for writing unbound-exporter. I'm trying to deploy it on both amd64 and arm64 and that's why I need platform-independent binaries.

Thanks!